### PR TITLE
MEDIA: IOS7 update background SVGs—fill corners to prevent artifacts

### DIFF
--- a/derivate/scummvm_ios7_icon.svg
+++ b/derivate/scummvm_ios7_icon.svg
@@ -7,8 +7,7 @@
 <style type="text/css">
 	.st0{fill:#CC6600;}
 </style>
-<path id="rect2867" class="st0" d="M21.3,0h85.4C118.5,0,128,9.5,128,21.3v85.4c0,11.8-9.5,21.3-21.3,21.3H21.3
-	C9.5,128,0,118.5,0,106.7V21.3C0,9.5,9.5,0,21.3,0z"/>
+<path id="rect2867" class="st0" d="M0,0h128v128H0V0Z"/>
 <image style="overflow:visible;enable-background:new    ;" width="512" height="512" id="image2860" xlink:href="../scummvm_icon.png"  sodipodi:absref="C:\dev\scummvm-media\derivate\../scummvm_icon.png" transform="matrix(0.2148 0 0 0.2148 9 9)">
 </image>
 </svg>

--- a/derivate/scummvm_ios7_tinted_icon.svg
+++ b/derivate/scummvm_ios7_tinted_icon.svg
@@ -40,8 +40,7 @@
 <style type="text/css">
 	.st0{fill:#000000;}
 </style>
-<path id="rect2867" class="st0" d="M21.3,0h85.4C118.5,0,128,9.5,128,21.3v85.4c0,11.8-9.5,21.3-21.3,21.3H21.3
-	C9.5,128,0,118.5,0,106.7V21.3C0,9.5,9.5,0,21.3,0z"/>
+<path id="rect2867" class="st0" d="M0,0h128v128H0V0Z"/>
 <image
    style="overflow:visible;enable-background:new    ;"
    width="512"


### PR DESCRIPTION
This PR updates source background SVGs for two iOS icon variants (the third variant doesn't currently need it). It takes their background colors to their corners. The icons generated therefrom will no longer have white in usually-invisible-areas.

Why is this necessary? When swiping upward to return to the Home screen, a subsequent operating-system-generated animation reveals the otherwise hidden white corners. See clip:

https://github.com/user-attachments/assets/14b3f9ea-ce0f-4adc-a882-8bcbe165a3f9

![Screen Shot 2025-02-16 at 5 17 48 PM](https://github.com/user-attachments/assets/c66026a8-89b6-4ce6-8baa-13143bedfe10)

Before & after image samples:
![icon4-83 5@2x](https://github.com/user-attachments/assets/43e92a5c-15cd-4716-8a68-31933143eb6c) _ ![icon4-83 5@2x](https://github.com/user-attachments/assets/e997581e-9bd8-4ac7-9d3a-69ce39c2488c)

This will **not** result in visibly square icons on iOS devices' home screens. iOS automatically handles icon corner-rounding.

See [#6453](https://github.com/scummvm/scummvm/pull/6453) over on the main project.